### PR TITLE
Allow `Address` to accept hostnames

### DIFF
--- a/devp2p/tests/test_discovery.py
+++ b/devp2p/tests/test_discovery.py
@@ -15,6 +15,7 @@ def test_address():
 
     ipv4 = '127.98.19.21'
     ipv6 = '5aef:2b::8'
+    hostname = 'localhost'
     port = 1
 
     a4 = Address(ipv4, port)
@@ -28,19 +29,21 @@ def test_address():
     assert a4 == Address.from_binary(*b_a4)
 
     b_a6 = a6.to_binary()
-    assert len(b_a6) == 2
+    assert len(b_a6) == 3
     assert a6 == Address.from_binary(*b_a6)
 
     e_a4 = a4.to_endpoint()
-    assert a4 == Address.from_endpoint(e_a4)
+    assert a4 == Address.from_endpoint(*e_a4)
 
     e_a6 = a6.to_endpoint()
-    assert a6 == Address.from_endpoint(e_a6)
+    assert a6 == Address.from_endpoint(*e_a6)
 
     assert len(b_a6[0]) == 16
     assert len(b_a4[0]) == 4
     assert isinstance(b_a6[1], str)
 
+    host_a = Address(hostname, port)
+    assert host_a.ip in ("127.0.0.1", "::1")
 
 #############################
 


### PR DESCRIPTION
Useful when connecting to bootstrap nodes.
Includes test fixes.