### PR TITLE
Remove bootstrap nodes from default config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ output/*/index.html
 # Sphinx
 docs/_build
 .eggs
+.cache

--- a/devp2p/discovery.py
+++ b/devp2p/discovery.py
@@ -516,12 +516,6 @@ class NodeDiscovery(BaseService, DiscoveryProtocolTransport):
         discovery=dict(
             listen_port=30303,
             listen_host='0.0.0.0',
-            bootstrap_nodes=dict(
-                cpp_bootstrap='enode://487611428e6c99a11a9795a6abe7b529e81315ca6aad66e2a2fc76e3adf263faba0d35466c2f8f68d561dbefa8878d4df5f1f2ddb1fbeab7f42ffb8cd328bd4a@5.1.83.226:30303',
-                go_bootstrap='enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303',
-                go_bootstrap2='enode://de471bccee3d042261d52e9bff31458daecc406142b401d4cd848f677479f73104b9fdeb090af9583d3391b7f10cb2ba9e26865dd5fca4fcdc0fb1e3b723c786@54.94.239.50:30303',
-                py_bootstrap='enode://2676755dd8477ad3beea32b4e5a144fa10444b70dfa3e05effb0fdfa75683ebd4f75709e1f8126cb5317c5a35cae823d503744e790a3a038ae5dd60f51ee9101@144.76.62.101:30303',
-            ).values()
         ),
         node=dict(privkey_hex=''))
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ install_requires = [install_requires_replacements.get(r, r) for r in install_req
 
 setup(
     name='devp2p',
-    version='0.5.9',
+    version='0.6.0',
     description='Python implementation of the Ethereum P2P stack',
     long_description=readme + '\n\n' + history,
     author='HeikoHeiko',


### PR DESCRIPTION
The bootstrap nodes are application specific and will now be included in PyEthApp's profile configuration (see: ethereum/pyethapp#74).
