### PR TITLE
Add c_secp256k1 support and exclusively use pycryptodome for sha3_256 hashing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,13 @@ Full spec:
 
 * https://github.com/ethereum/devp2p/blob/master/rlpx.md
 
+Dependencies
+------------
+
+On Ubuntu::
+
+    $ sudo apt-get install libssl-dev libffi-dev libtool
+
 Features
 --------
 * Node Discovery and Network Formation

--- a/devp2p/crypto.py
+++ b/devp2p/crypto.py
@@ -29,10 +29,12 @@ sha3_256 = lambda x: keccak.new(digest_bits=256, data=x)
 from hashlib import sha256
 import struct
 try:
-    from c_secp256k1 import ecdsa_raw_sign, ecdsa_raw_recover, ecdsa_raw_verify
+    from c_secp256k1 import ecdsa_sign_raw, ecdsa_recover_raw, ecdsa_verify_raw
 except ImportError:
     warnings.warn('could not import c_secp256k1, fallback to bitcointools')
-    from bitcoin import ecdsa_raw_sign, ecdsa_raw_recover, ecdsa_raw_verify
+    from bitcoin import ecdsa_raw_sign as ecdsa_sign_raw
+    from bitcoin import ecdsa_raw_recover as ecdsa_recover_raw
+    from bitcoin import ecdsa_raw_verify as ecdsa_verify_raw
 
 
 hmac_sha256 = pyelliptic.hmac_sha256
@@ -237,13 +239,13 @@ def _decode_sig(sig):
 def ecdsa_verify(pubkey, signature, message):
     assert len(signature) == 65
     assert len(pubkey) == 64
-    return ecdsa_raw_verify(message, _decode_sig(signature), pubkey)
+    return ecdsa_verify_raw(message, _decode_sig(signature), pubkey)
 verify = ecdsa_verify
 
 
 def ecdsa_sign(msghash, privkey):
     assert len(msghash) == 32
-    s = _encode_sig(*ecdsa_raw_sign(msghash, privkey))
+    s = _encode_sig(*ecdsa_sign_raw(msghash, privkey))
     return s
 
 sign = ecdsa_sign
@@ -251,7 +253,7 @@ sign = ecdsa_sign
 
 def ecdsa_recover(message, signature):
     assert len(signature) == 65
-    pub = ecdsa_raw_recover(message, _decode_sig(signature))
+    pub = ecdsa_recover_raw(message, _decode_sig(signature))
     assert pub, 'pubkey could not be recovered'
     pub = bitcoin.encode_pubkey(pub, 'bin_electrum')
     assert len(pub) == 64

--- a/devp2p/crypto.py
+++ b/devp2p/crypto.py
@@ -24,7 +24,8 @@ if 'pyelliptic' not in dir() or not CIPHERNAMES.issubset(set(pyelliptic.Cipher.g
     sys.exit(1)
 
 import bitcoin
-from sha3 import sha3_256
+from Crypto.Hash import keccak
+sha3_256 = lambda x: keccak.new(digest_bits=256, data=x)
 from hashlib import sha256
 import struct
 try:

--- a/devp2p/rlpxcipher.py
+++ b/devp2p/rlpxcipher.py
@@ -2,7 +2,8 @@
 import random
 import struct
 from devp2p.crypto import sha3
-from sha3 import sha3_256
+from Crypto.Hash import keccak
+sha3_256 = lambda x: keccak.new(digest_bits=256, update_after_digest=True, data=x)
 from devp2p.crypto import ECCx
 from devp2p.crypto import ecdsa_recover
 from devp2p.crypto import ecdsa_verify

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ bitcoin
 ipaddress
 pytest
 pytest-catchlog==1.1
-pytest-timeout
+pytest-timeout==0.5
 coverage
 tox
 c_secp256k1>=0.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ pyelliptic
 wheel
 gevent==1.1b3
 tinyrpc
-pysha3
 bitcoin
 ipaddress
 pytest
@@ -10,5 +9,5 @@ pytest-catchlog==1.1
 pytest-timeout
 coverage
 tox
-pycryptodome
+pycryptodome>=3.3.1
 https://github.com/ethereum/pyrlp/tarball/develop

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ pytest-catchlog==1.1
 pytest-timeout
 coverage
 tox
-c_secp256k1>=0.0.6
+c_secp256k1>=0.0.7
 pycryptodome>=3.3.1
 https://github.com/ethereum/pyrlp/tarball/develop

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ pytest-catchlog==1.1
 pytest-timeout
 coverage
 tox
+c_secp256k1>=0.0.6
 pycryptodome>=3.3.1
 https://github.com/ethereum/pyrlp/tarball/develop


### PR DESCRIPTION
This does not add pypy support since there is a problem with c_secp256k1 and pypy still
Use c_secp256k1 lib wrapper of the bitcoin libsecp256k1 to speed up recoveries
Use pycryptodome exclusively since it now also supports pypy
Add dependencies for c_secp256k1 to README
