### PR TITLE
Move test requirements to test_requirement list in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,6 @@ tinyrpc
 pysha3
 bitcoin
 ipaddress
-pytest
-pytest-catchlog==1.1
-pytest-timeout==0.5
 coverage
 tox
 pycryptodome

--- a/setup.py
+++ b/setup.py
@@ -30,13 +30,16 @@ class PyTest(TestCommand):
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
-
-test_requirements = []
-
 install_requires = set(x.strip() for x in open('requirements.txt'))
 install_requires_replacements = {
     'https://github.com/ethereum/pyrlp/tarball/develop': 'rlp>=0.3.9'}
 install_requires = [install_requires_replacements.get(r, r) for r in install_requires]
+
+test_requirements = [
+    'pytest',
+    'pytest-catchlog==1.1',
+    'pytest-timeout==0.5'
+]
 
 setup(
     name='devp2p',


### PR DESCRIPTION
Do not install pytest with `setup.py install` / `pip install -r requirements.txt`. Pytest is only needed for testing.
