### PR TITLE
Clean up "Full App" example

### DIFF
--- a/devp2p/app_helper.py
+++ b/devp2p/app_helper.py
@@ -1,17 +1,10 @@
-import time
 from devp2p import peermanager
-from devp2p.app import BaseApp
-from devp2p.protocol import BaseProtocol, SubProtocolError
 from devp2p.service import BaseService
 from devp2p.discovery import NodeDiscovery
 from devp2p.crypto import privtopub as privtopub_raw, sha3
-from devp2p.utils import host_port_pubkey_to_uri, update_config_with_defaults, colors
-import rlp
+from devp2p.utils import host_port_pubkey_to_uri, update_config_with_defaults
 import gevent
-from gevent.event import Event
-import signal
 import copy
-import sys
 
 
 def mk_privkey(seed):

--- a/devp2p/examples/full_app.py
+++ b/devp2p/examples/full_app.py
@@ -1,5 +1,4 @@
 import sys
-import time
 import random
 from devp2p.app import BaseApp
 from devp2p.protocol import BaseProtocol
@@ -45,7 +44,7 @@ class Token(rlp.Serializable):
 class ExampleProtocol(BaseProtocol):
     protocol_id = 1
     network_id = 0
-    max_cmd_id = 15  # FIXME
+    max_cmd_id = 1  # Actually max id is 0, but 0 is the special value.
     name = 'example'
     version = 1
 
@@ -60,7 +59,6 @@ class ExampleProtocol(BaseProtocol):
         message sending a token and a nonce
         """
         cmd_id = 0
-        sent = False
 
         structure = [
             ('token', Token)


### PR DESCRIPTION
- Remove `sent` flag of `ExampleProtocol.token`.
- Set the best possible `max_cmd_id` value for `ExampleProtocol`.
- Remove unused imports.
