### PR TITLE
fix variable name collision in discovery recv_neighbours

### DIFF
--- a/devp2p/discovery.py
+++ b/devp2p/discovery.py
@@ -503,9 +503,9 @@ class DiscoveryProtocol(kademlia.WireInterface):
             n = list(n)
             nodeid = n.pop()
             address = Address.from_endpoint(*n)
-            node = self.get_node(nodeid, address)
-            assert node.address
-            neighbours.append(node)
+            _node = self.get_node(nodeid, address)
+            assert _node.address
+            neighbours.append(_node)
         self.kademlia.recv_neighbours(node, neighbours)
 
 


### PR DESCRIPTION
### Problem

In `recv_neighbours` of discovery.py, variable `node` is reused to get neighbours set, make node refer to the last neighbour instead of the packet sender.
### Solution

Use a different variable `_node` to get neighbours.
