### PR TITLE
fix multiplexer, payload should be str

### DIFF
--- a/devp2p/multiplexer.py
+++ b/devp2p/multiplexer.py
@@ -508,11 +508,9 @@ class Multiplexer(object):
             # body normal, chunked-0: rlp(packet-type) [|| rlp(packet-data)] || padding
             item, end = rlp.codec.consume_item(body, 0)
             cmd_id = rlp.sedes.big_endian_int.deserialize(item)
+            payload = body[end:]
             if chunked_0:
-                payload = bytearray(body[end:])
                 total_payload_size -= end
-            else:
-                payload = body[end:]
 
             packet = Packet(protocol_id=protocol_id, cmd_id=cmd_id, payload=payload)
             if chunked_0:


### PR DESCRIPTION
I got this error occasionally:

``` shell
Traceback (most recent call last):
  File "/home/jan/.envs/pyethapp/lib/python2.7/site-packages/gevent/greenlet.py", line 534, in run
    result = self._run(*self.args, **self.kwargs)
  File "/home/jan/projects/opensource/pydevp2p/devp2p/peer.py", line 230, in _run_decoded_packets
    self._handle_packet(self.mux.packet_queue.get())  # get_packet blocks
  File "/home/jan/projects/opensource/pydevp2p/devp2p/peer.py", line 204, in _handle_packet
    protocol.receive_packet(packet)
  File "/home/jan/projects/opensource/pydevp2p/devp2p/protocol.py", line 165, in receive_packet
    cmd(packet)
  File "/home/jan/projects/opensource/pydevp2p/devp2p/protocol.py", line 137, in receive
    instance.receive(proto=self, data=klass.decode_payload(packet.payload))
  File "/home/jan/projects/opensource/pyethapp/pyethapp/eth_protocol.py", line 139, in decode_payload
    for block in rlp.decode_lazy(rlp_data):
  File "/home/jan/.envs/pyethapp/lib/python2.7/site-packages/rlp/lazy.py", line 30, in decode_lazy
    item, end = consume_item_lazy(rlp, 0)
  File "/home/jan/.envs/pyethapp/lib/python2.7/site-packages/rlp/lazy.py", line 55, in consume_item_lazy
    t, l, s = consume_length_prefix(rlp, start)
  File "/home/jan/.envs/pyethapp/lib/python2.7/site-packages/rlp/codec.py", line 124, in consume_length_prefix
    b0 = safe_ord(rlp[start])
TypeError: ord() expected string of length 1, but int found
<Greenlet at 0x7fe5b969b190: <bound method Peer._run_decoded_packets of <Peer('127.0.0.1', 41306) pyethapp/v1.4.0>>> failed with TypeError
```
