### PR TITLE
bump rlp to 0.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ coverage
 tox
 secp256k1==0.13.2
 pycryptodome>=3.3.1
-rlp==0.4.7
+rlp==0.5.0


### PR DESCRIPTION
Bump the upstream version of `rlp` to `0.5.0`

![l_9b78bcd0-8e10-11e1-bff3-795e9d600001](https://cloud.githubusercontent.com/assets/824194/24918970/7b25872c-1e9f-11e7-9446-84a38e536b40.jpeg)
