### PR TITLE
Exception SyntaxError fix

### DIFF
--- a/devp2p/peer.py
+++ b/devp2p/peer.py
@@ -210,7 +210,7 @@ class Peer(gevent.Greenlet):
             protocol.receive_packet(packet)
         except UnknownCommandError as e:
             log.debug('received unknown cmd', peer=self, error=e, packet=packet)
-        except Exception, e:
+        except Exception as e:
             log.debug('failed to handle packet', peer=self, error=e)
             self.stop()
 


### PR DESCRIPTION
Make the exception catching compatible with both Python2 and Python3.