### PR TITLE
Teardown k_request_timeout

### DIFF
--- a/devp2p/tests/test_discovery.py
+++ b/devp2p/tests/test_discovery.py
@@ -4,6 +4,7 @@ from devp2p import crypto
 from devp2p.app import BaseApp
 from rlp.utils import decode_hex, encode_hex
 from devp2p.utils import remove_chars
+import pytest
 import gevent
 import random
 
@@ -233,13 +234,26 @@ def test_ping_pong_udp():
     assert bob_node in alice_discovery.protocol.kademlia.routing
 
 
-def test_bootstrap_udp():
+# must use yield_fixture rather than fixture prior to pytest 2.10
+@pytest.yield_fixture
+def kademlia_timeout():
+    """
+    Rolls back kademlia timeout after the test.
+    """
+    # backup the previous value
+    k_request_timeout = kademlia.k_request_timeout
+    # return kademlia
+    yield kademlia
+    # restore the previous value
+    kademlia.k_request_timeout = k_request_timeout
+
+def test_bootstrap_udp(kademlia_timeout):
     """
     startup num_apps udp server and node applications
     """
 
     # set timeout to something more tolerant
-    kademlia.k_request_timeout = 10000.
+    kademlia_timeout.k_request_timeout = 10000.
 
     num_apps = 6
     apps = []

--- a/devp2p/tests/test_kademlia_protocol.py
+++ b/devp2p/tests/test_kademlia_protocol.py
@@ -135,7 +135,6 @@ def test_setup():
 
 
 @pytest.mark.timeout(5)
-@pytest.mark.xfail
 def test_find_node_timeout():
     proto = get_wired_protocol()
     other = routing_table()
@@ -186,7 +185,6 @@ def test_eviction():
 
 
 @pytest.mark.timeout(5)
-@pytest.mark.xfail
 def test_eviction_timeout():
     proto = get_wired_protocol()
     proto.routing = routing_table(1000)
@@ -277,7 +275,6 @@ def test_eviction_node_active():
 
 
 @pytest.mark.timeout(5)
-@pytest.mark.xfail
 def test_eviction_node_inactive():
     """
     active nodes (replying in time) should not be evicted


### PR DESCRIPTION
Makes sure kademlia.k_request_timeout gets reverted after use.
Fixes:

  - test_find_node_timeout()
  - test_eviction_timeout()
  - test_eviction_node_inactive()