### PR TITLE
Fix test_eviction_node_inactive failing on Python 3

### DIFF
--- a/devp2p/tests/test_kademlia_protocol.py
+++ b/devp2p/tests/test_kademlia_protocol.py
@@ -317,7 +317,7 @@ def test_eviction_node_inactive():
     assert msg[0] == 'ping'
     assert msg[1] == proto.this_node
     assert len(proto._expected_pongs) == 1
-    expected_pingid = proto._expected_pongs.keys()[0]
+    expected_pingid = list(proto._expected_pongs.keys())[0]
     assert len(expected_pingid) == 96
     echo = expected_pingid[:32]
     assert len(echo) == 32


### PR DESCRIPTION
On Python 3 `dict.keys()` returns `dict_keys` instead of a
list, so `[0]` doesn't work on it. Wrap it in a list before
getting the first element.