### PR TITLE
Fix offset-based cmd_id translation

### DIFF
--- a/devp2p/tests/test_peer.py
+++ b/devp2p/tests/test_peer.py
@@ -11,7 +11,7 @@ import devp2p.p2p_protocol
 import time
 import gevent
 import copy
-from rlp.utils import encode_hex, decode_hex
+from rlp.utils import encode_hex, decode_hex, str_to_bytes
 
 
 def get_connected_apps():
@@ -120,7 +120,7 @@ def test_offset_dispatch():
         class MockProtocol(devp2p.protocol.BaseProtocol):
             protocol_id = n
             max_cmd_id = size
-            name = b'mock%d' % n
+            name = str_to_bytes('mock%d' % n)
             version = 1
             def __init__(self, *args, **kwargs):
                 super(MockProtocol, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Make the loops in Peer.protocol_cmd_id_from_packet and
Peer.send_packet sum the max_ids correctly.

Before, they would break whenever there was more than 2 protocols.

Also add a regression test to check that the translation is its own inverse.

Note that while I did look at how geth does this translation before making this change, I haven't check if this is still compatible with other devp2p implementation.