### PR TITLE
Don't try to send through closed socket in NodeDiscovery

### DIFF
--- a/devp2p/discovery.py
+++ b/devp2p/discovery.py
@@ -548,6 +548,10 @@ class NodeDiscovery(BaseService, DiscoveryProtocolTransport):
     #     sock.send(message)
 
     def send(self, address, message):
+        if not self.server or self.server.closed:
+            log.warning("DiscoveryNode trying to send but socket is closed")
+            return
+
         assert isinstance(address, Address)
         log.debug('sending', size=len(message), to=address)
         try:


### PR DESCRIPTION
When stopping the services, and PeerManager is still alive after
NodeDiscovery was stopped, it may try to send some discovery messages.
This will cause DatagramServer.sendto to throw AttributeError, because
a closed DatagramServer doesn't have a `socket` attribute.

Prevent this, by checking if the DatagramServer is closed, and dropping
the message if it is.