### PR TITLE
Bump rlp version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ coverage
 tox
 coincurve>=5.0.1
 pycryptodome>=3.3.1
-rlp>=0.5.1,<0.6.0
+rlp>=0.6.0,<0.7.0
 miniupnpc
 repoze.lru


### PR DESCRIPTION
The latest `rlp` version is `0.6.0`: https://pypi.python.org/pypi/rlp .
This PR bumps `rlp` version from `0.5.1,<0.6.0` to `0.6.0,<0.7.0`.
