### PR TITLE
Fixed compatible_p2p_version #89

### DIFF
--- a/devp2p/p2p_protocol.py
+++ b/devp2p/p2p_protocol.py
@@ -149,7 +149,7 @@ class P2PProtocol(BaseProtocol):
             useless_peer = 3
             too_many_peers = 4
             already_connected = 5
-            incompatibel_p2p_version = 6
+            incompatible_p2p_version = 6
             null_node_identity_received = 7
             client_quitting = 8
             unexpected_identity = 9  # i.e. a different identity to a previous connection or

--- a/devp2p/peer.py
+++ b/devp2p/peer.py
@@ -29,6 +29,7 @@ class Peer(gevent.Greenlet):
     offset_based_dispatch = False
     wait_read_timeout = 0.001
     dumb_remote_timeout = 10.0
+    compatible_p2p_version = 5
 
     def __init__(self, peermanager, connection, remote_pubkey=None):
         super(Peer, self).__init__()
@@ -126,9 +127,11 @@ class Peer(gevent.Greenlet):
         self.hello_received = True
 
         # enable backwards compatibility for legacy peers
-        if version < 5:
+        if version <= self.compatible_p2p_version:
             self.offset_based_dispatch = True
             max_window_size = 2**32  # disable chunked transfers
+        else:
+            proto.send_disconnect(proto.disconnect.reason.incompatible_p2p_version)
 
         # call peermanager
         agree = self.peermanager.on_hello_received(


### PR DESCRIPTION
Fixed #89：Version clash with devp2p v5 as defined by EIP706 

1. Since devp2p v5 is defined by EIP706, set the `compatible_p2p_version`
to 5.
2. Assuming that pyethapp doesn't compatible with above version, disconnect
if the peer uses devp2p>v5.