### PR TITLE
add _init_upnp return value

### DIFF
--- a/devp2p/upnp.py
+++ b/devp2p/upnp.py
@@ -19,6 +19,9 @@ def _init_upnp():
         _upnp = u
     except Exception as e:
         log.debug('Exception :%s', e)
+    finally:
+        return _upnp
+
 
 def add_portmap(port, proto, label=''):
     u = _init_upnp()


### PR DESCRIPTION
A  returned value for _init_upnp is needed by add_portmap, otherwise the later call for u.selectigd would fail