### PR TITLE
Explicitly open text files as utf-8 encoded

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,12 @@ except ImportError:
     from distutils.core import setup
 
 
-readme = open('README.rst').read()
-history = open('HISTORY.rst').read().replace('.. :changelog:', '')
+from io import open
 
-install_requires = set(x.strip() for x in open('requirements.txt'))
+readme = open('README.rst', encoding='utf-8').read()
+history = open('HISTORY.rst', encoding='utf-8').read().replace('.. :changelog:', '')
+
+install_requires = set(x.strip() for x in open('requirements.txt', encoding='utf-8'))
 install_requires_replacements = {
 }
 install_requires = [install_requires_replacements.get(r, r) for r in install_requires]


### PR DESCRIPTION
Fixes `UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 1569: character maps to <undefined>` when trying to pip install.

There is a very similar PR open for this same issue (https://github.com/ethereum/pydevp2p/pull/87) but this PR doesn't specify the encoding when opening requirements.txt. This is not currently an issue, but will exhibit the same error message if requirements.txt is ever changed to contain e.g. ÐΞ characters.